### PR TITLE
add googe-ad

### DIFF
--- a/.github/workflows/BuildActionToNetlify.yml
+++ b/.github/workflows/BuildActionToNetlify.yml
@@ -42,4 +42,8 @@ jobs:
           echo "::endgroup::"
         env:
           NETLIFY_SITE_ID   : ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_REDIRECT }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+
+      - name: Set AdSense ID
+        run: |
+          sed -i 's/\${NEXT_PUBLIC_ADSENSE_ID}/${{ secrets.NEXT_PUBLIC_ADSENSE_ID }}/g' index.html

--- a/.github/workflows/BuildActionToNetlify_PR.yml
+++ b/.github/workflows/BuildActionToNetlify_PR.yml
@@ -31,7 +31,7 @@ jobs:
           echo "::endgroup::"
         env:
           NETLIFY_SITE_ID   : ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_REDIRECT }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Post Netlify CLI Comment
         run: |
@@ -77,3 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           URL: ${{ github.event.pull_request.comments_url }}
+
+      - name: Set AdSense ID
+        run: |
+          sed -i 's/\${NEXT_PUBLIC_ADSENSE_ID}/${{ secrets.NEXT_PUBLIC_ADSENSE_ID }}/g' index.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/index.html
+++ b/index.html
@@ -3,14 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>リダイレクトページ</title>
+    <title>Redirect Page</title>
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${NEXT_PUBLIC_ADSENSE_ID}"
+      crossorigin="anonymous">
+    </script>
   </head>
   <body>
-    <h1>ページは移動しました</h1>
-    <p>新しいURLに自動的に転送されます。</p>
+    <h1>Redirect Page</h1>
     <p>
-      転送されない場合は、<a href="https://blog.ec-maker.com">こちら</a
-      >をクリックしてください。
+      If you are not redirected, please click <a href="https://blog.ec-maker.com">here</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
actionsで環境変数を埋め込めるらしい。

1. GitHub Actions などの CI/CD ツールを用いて、デプロイ時に環境変数を埋め込む この方法では、.env ファイルは使用しません。代わりに、GitHub リポジトリの Secrets に NEXT_PUBLIC_ADSENSE_ID を設定し、GitHub Actions のワークフロー内でその値を index.html に埋め込むようにします。